### PR TITLE
Add reviews API and integrate ratings UI

### DIFF
--- a/src/app/api/reviews/[id]/route.ts
+++ b/src/app/api/reviews/[id]/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(_req: NextRequest, { params }: any) {
+  try {
+    const review = await prisma.review.findUnique({
+      where: { id: params.id },
+      select: {
+        id: true,
+        rating: true,
+        comment: true,
+        createdAt: true,
+        buyer: { select: { id: true, name: true } },
+        sellerId: true,
+        itemId: true,
+        transactionId: true
+      }
+    })
+    if (!review) return NextResponse.json({ message: 'Not found' }, { status: 404 })
+    return NextResponse.json(review)
+  } catch (e) {
+    console.error('[REVIEW_ID_GET]', e)
+    return NextResponse.json({ message: 'Error' }, { status: 500 })
+  }
+}
+
+export async function PATCH(req: NextRequest, { params }: any) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user) return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+  try {
+    const { rating, comment } = await req.json()
+    if (!rating && !comment) return NextResponse.json({ message: 'Nothing to update' }, { status: 400 })
+    const result = await prisma.$transaction(async (p) => {
+      const existing = await p.review.findUnique({ where: { id: params.id } })
+      if (!existing) return null
+      if (existing.buyerId !== session.user.id) throw new Error('FORBIDDEN')
+
+      const updated = await p.review.update({
+        where: { id: params.id },
+        data: { rating: rating ?? existing.rating, comment: comment ?? existing.comment }
+      })
+
+      const item = await p.item.findUnique({
+        where: { id: existing.itemId },
+        select: { totalRating: true, numReviews: true }
+      })
+      const newTotal = (item?.totalRating || 0) - existing.rating + (rating ?? existing.rating)
+      const newCount = item?.numReviews || 0
+      await p.item.update({
+        where: { id: existing.itemId },
+        data: {
+          totalRating: newTotal,
+          numReviews: newCount,
+          avgRating: newCount ? newTotal / newCount : 0
+        }
+      })
+
+      return updated
+    })
+    if (!result) return NextResponse.json({ message: 'Not found' }, { status: 404 })
+    return NextResponse.json(result)
+  } catch (e: any) {
+    if (e.message === 'FORBIDDEN') {
+      return NextResponse.json({ message: 'Forbidden' }, { status: 403 })
+    }
+    console.error('[REVIEW_PATCH]', e)
+    return NextResponse.json({ message: 'Error' }, { status: 500 })
+  }
+}
+
+export async function DELETE(_req: NextRequest, { params }: any) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user) return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+  try {
+    const result = await prisma.$transaction(async (p) => {
+      const existing = await p.review.findUnique({ where: { id: params.id } })
+      if (!existing) return null
+      if (existing.buyerId !== session.user.id) throw new Error('FORBIDDEN')
+
+      await p.review.delete({ where: { id: params.id } })
+      const item = await p.item.findUnique({
+        where: { id: existing.itemId },
+        select: { totalRating: true, numReviews: true }
+      })
+      const newTotal = (item?.totalRating || 0) - existing.rating
+      const newCount = (item?.numReviews || 0) - 1
+      await p.item.update({
+        where: { id: existing.itemId },
+        data: {
+          totalRating: newTotal,
+          numReviews: newCount,
+          avgRating: newCount > 0 ? newTotal / newCount : 0
+        }
+      })
+      return existing
+    })
+    if (!result) return NextResponse.json({ message: 'Not found' }, { status: 404 })
+    return NextResponse.json({ success: true })
+  } catch (e: any) {
+    if (e.message === 'FORBIDDEN') {
+      return NextResponse.json({ message: 'Forbidden' }, { status: 403 })
+    }
+    console.error('[REVIEW_DELETE]', e)
+    return NextResponse.json({ message: 'Error' }, { status: 500 })
+  }
+}

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url)
+    const itemId = searchParams.get('itemId')
+    const sellerId = searchParams.get('sellerId')
+    const buyerId = searchParams.get('buyerId')
+    const transactionId = searchParams.get('transactionId')
+
+    const where: any = {}
+    if (itemId) where.itemId = itemId
+    if (sellerId) where.sellerId = sellerId
+    if (buyerId) where.buyerId = buyerId
+    if (transactionId) where.transactionId = transactionId
+
+    const reviews = await prisma.review.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        rating: true,
+        comment: true,
+        createdAt: true,
+        buyer: { select: { id: true, name: true } }
+      }
+    })
+
+    const summary = await prisma.review.aggregate({
+      where,
+      _avg: { rating: true },
+      _count: { rating: true }
+    })
+
+    return NextResponse.json({
+      reviews,
+      avgRating: summary._avg.rating || 0,
+      numReviews: summary._count.rating
+    })
+  } catch (e) {
+    console.error('[REVIEW_GET]', e)
+    return NextResponse.json({ message: 'Error' }, { status: 500 })
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user) return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+  try {
+    const { transactionId, rating, comment } = await req.json()
+    if (!transactionId || !rating) {
+      return NextResponse.json({ message: 'Missing fields' }, { status: 400 })
+    }
+
+    const tx = await prisma.transaction.findUnique({
+      where: { id: transactionId },
+      select: { id: true, buyerId: true, sellerId: true, itemId: true, status: true }
+    })
+    if (!tx || tx.status !== 'COMPLETED') {
+      return NextResponse.json({ message: 'Invalid transaction' }, { status: 400 })
+    }
+    if (tx.buyerId !== session.user.id) {
+      return NextResponse.json({ message: 'Forbidden' }, { status: 403 })
+    }
+
+    const result = await prisma.$transaction(async (p) => {
+      const created = await p.review.create({
+        data: {
+          transactionId,
+          rating,
+          comment: comment || '',
+          itemId: tx.itemId,
+          buyerId: tx.buyerId,
+          sellerId: tx.sellerId
+        }
+      })
+
+      const item = await p.item.findUnique({
+        where: { id: tx.itemId },
+        select: { totalRating: true, numReviews: true }
+      })
+      const newTotal = (item?.totalRating || 0) + rating
+      const newCount = (item?.numReviews || 0) + 1
+      await p.item.update({
+        where: { id: tx.itemId },
+        data: {
+          totalRating: newTotal,
+          numReviews: newCount,
+          avgRating: newTotal / newCount
+        }
+      })
+
+      return created
+    })
+
+    return NextResponse.json(result, { status: 201 })
+  } catch (e) {
+    console.error('[REVIEW_POST]', e)
+    return NextResponse.json({ message: 'Error' }, { status: 500 })
+  }
+}

--- a/src/app/dashboard/seller/seller-dashboard.tsx
+++ b/src/app/dashboard/seller/seller-dashboard.tsx
@@ -4,11 +4,28 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
-import { useState } from "react"
+import { useEffect, useState } from "react"
+import { useSession } from "next-auth/react"
 
 export default function SellerDashboard() {
   const router = useRouter()
   const [isDowngrading, setIsDowngrading] = useState(false)
+  const { data: session } = useSession()
+  const [rating, setRating] = useState<{ avg: number; count: number }>({ avg: 0, count: 0 })
+
+  useEffect(() => {
+    const load = async () => {
+      if (!session?.user?.id) return
+      try {
+        const res = await fetch(`/api/reviews?sellerId=${session.user.id}`)
+        if (res.ok) {
+          const data = await res.json()
+          setRating({ avg: data.avgRating || 0, count: data.numReviews || 0 })
+        }
+      } catch {}
+    }
+    load()
+  }, [session?.user?.id])
 
   const handleDowngrade = async () => {
     if (!confirm("Are you sure you want to switch back to buyer mode? You can always become a seller again later.")) {
@@ -53,7 +70,7 @@ export default function SellerDashboard() {
       </div>
 
       {/* Quick Stats */}
-      <div className="grid gap-4 md:grid-cols-3 mb-6">
+      <div className="grid gap-4 md:grid-cols-4 mb-6">
         <Card>
           <CardHeader>
             <CardTitle>Active Listings</CardTitle>
@@ -79,6 +96,16 @@ export default function SellerDashboard() {
           </CardHeader>
           <CardContent>
             <p className="text-3xl font-bold">Rp 0</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Rating</CardTitle>
+            <CardDescription>Your seller rating</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-bold">{rating.avg.toFixed(1)}</p>
+            <p className="text-sm text-muted-foreground">{rating.count} reviews</p>
           </CardContent>
         </Card>
       </div>

--- a/src/app/items/[id]/client-page.tsx
+++ b/src/app/items/[id]/client-page.tsx
@@ -11,6 +11,7 @@ import { useState } from 'react'
 import { useSession, signIn } from 'next-auth/react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
 import { Separator as Hr } from '@/components/ui/separator'
+import { useEffect } from 'react'
 
 type ItemDetails = {
   id: string
@@ -32,6 +33,20 @@ export function ClientSideItemPage({ item }: { item: ItemDetails }) {
   const [startingChat, setStartingChat] = useState(false)
   const { data: session, status } = useSession()
   const [showLoginPrompt, setShowLoginPrompt] = useState(false)
+  const [rating, setRating] = useState<{ avg: number; count: number }>({ avg: 0, count: 0 })
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/reviews?sellerId=${item.seller.id}`)
+        if (res.ok) {
+          const data = await res.json()
+          setRating({ avg: data.avgRating || 0, count: data.numReviews || 0 })
+        }
+      } catch {}
+    }
+    load()
+  }, [item.seller.id])
 
   const handleStartChat = async () => {
     if (!session?.user) {
@@ -91,6 +106,9 @@ export function ClientSideItemPage({ item }: { item: ItemDetails }) {
             <div className="mt-4 flex items-center gap-2">
               <span className="text-muted-foreground">Sold by {item.seller.name}</span>
               <VerificationBadge isVerified={item.seller.verificationStatus === "VERIFIED"} />
+              {rating.count > 0 && (
+                <span className="text-sm text-muted-foreground">⭐ {rating.avg.toFixed(1)} ({rating.count})</span>
+              )}
             </div>
 
             <Separator className="my-4" />


### PR DESCRIPTION
## Summary
- add review CRUD API endpoints
- enable buyers to submit reviews on completed transactions
- show seller rating on item pages and dashboard stats

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a82ea0215083328c5c6477e8b95e3c