### PR TITLE
feat: add 2fa support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "react-dom": "19.1.0",
         "react-hook-form": "^7.62.0",
         "sonner": "^2.0.7",
+        "speakeasy": "^2.0.0",
         "tailwind-merge": "^3.3.1",
         "zod": "^4.0.15"
       },
@@ -3268,6 +3269,12 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/base32.js": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.0.1.tgz",
+      "integrity": "sha512-EGHIRiegFa62/SsA1J+Xs2tIzludPdzM064N9wjbiEgHnGnJ1V0WEpA4pEwCYT5nDvZk3ubf0shqaCS7k6xeUQ==",
+      "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -7714,6 +7721,18 @@
       "version": "3.0.22",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
       "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ=="
+    },
+    "node_modules/speakeasy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/speakeasy/-/speakeasy-2.0.0.tgz",
+      "integrity": "sha512-lW2A2s5LKi8rwu77ewisuUOtlCydF/hmQSOJjpTqTj1gZLkNgTaYnyvfxy2WBr4T/h+9c4g8HIITfj83OkFQFw==",
+      "license": "MIT",
+      "dependencies": {
+        "base32.js": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-dom": "19.1.0",
     "react-hook-form": "^7.62.0",
     "sonner": "^2.0.7",
+    "speakeasy": "^2.0.0",
     "tailwind-merge": "^3.3.1",
     "zod": "^4.0.15"
   },

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -119,6 +119,8 @@ model User {
   name           String
   hashedPassword String
   role           UserRole @default(USER)
+  twoFactorEnabled Boolean @default(false)
+  twoFactorSecret String?
   username       String?  @unique
   bio            String?
   location       String?

--- a/src/app/api/auth/disable-2fa/route.ts
+++ b/src/app/api/auth/disable-2fa/route.ts
@@ -1,0 +1,20 @@
+import { getServerSession } from "next-auth"
+import { authOptions } from "@/lib/auth"
+import { prisma } from "@/lib/prisma"
+
+export async function POST() {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return new Response("Unauthorized", { status: 401 })
+  }
+
+  await prisma.user.update({
+    where: { id: session.user.id },
+    data: {
+      twoFactorEnabled: false,
+      twoFactorSecret: null,
+    },
+  })
+
+  return Response.json({ disabled: true })
+}

--- a/src/app/api/auth/enable-2fa/route.ts
+++ b/src/app/api/auth/enable-2fa/route.ts
@@ -1,0 +1,22 @@
+import { getServerSession } from "next-auth"
+import speakeasy from "speakeasy"
+import { authOptions } from "@/lib/auth"
+import { prisma } from "@/lib/prisma"
+
+export async function POST() {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return new Response("Unauthorized", { status: 401 })
+  }
+
+  const secret = speakeasy.generateSecret({ length: 20 })
+  await prisma.user.update({
+    where: { id: session.user.id },
+    data: {
+      twoFactorSecret: secret.base32,
+      twoFactorEnabled: false,
+    },
+  })
+
+  return Response.json({ secret: secret.base32, otpauthUrl: secret.otpauth_url })
+}

--- a/src/app/api/auth/verify-2fa/route.ts
+++ b/src/app/api/auth/verify-2fa/route.ts
@@ -1,0 +1,34 @@
+import { getServerSession } from "next-auth"
+import speakeasy from "speakeasy"
+import { authOptions } from "@/lib/auth"
+import { prisma } from "@/lib/prisma"
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return new Response("Unauthorized", { status: 401 })
+  }
+
+  const { token } = await req.json()
+  const user = await prisma.user.findUnique({ where: { id: session.user.id } })
+  if (!user?.twoFactorSecret) {
+    return new Response("2FA not setup", { status: 400 })
+  }
+
+  const verified = speakeasy.totp.verify({
+    secret: user.twoFactorSecret,
+    encoding: "base32",
+    token,
+  })
+
+  if (!verified) {
+    return new Response("Invalid token", { status: 400 })
+  }
+
+  await prisma.user.update({
+    where: { id: session.user.id },
+    data: { twoFactorEnabled: true },
+  })
+
+  return Response.json({ verified: true })
+}

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -19,6 +19,7 @@ export default function SignInPage() {
   const router = useRouter()
   const [error, setError] = useState("")
   const [isLoading, setIsLoading] = useState(false)
+  const [otpRequired, setOtpRequired] = useState(false)
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -28,15 +29,27 @@ export default function SignInPage() {
     const formData = new FormData(e.currentTarget)
     const email = formData.get("email") as string
     const password = formData.get("password") as string
+    const otp = formData.get("otp") as string
 
     try {
       const res = await signIn("credentials", {
         email,
         password,
+        otp,
         redirect: false,
       })
 
       if (res?.error) {
+        if (res.error === "OTP_REQUIRED") {
+          setOtpRequired(true)
+          setError("One-time password required")
+          return
+        }
+        if (res.error === "INVALID_OTP") {
+          setOtpRequired(true)
+          setError("Invalid one-time password")
+          return
+        }
         setError("Invalid email or password")
         return
       }
@@ -81,6 +94,18 @@ export default function SignInPage() {
                 required
               />
             </div>
+            {otpRequired && (
+              <div className="space-y-2">
+                <Label htmlFor="otp">One-Time Password</Label>
+                <Input
+                  id="otp"
+                  name="otp"
+                  type="text"
+                  placeholder="123456"
+                  required
+                />
+              </div>
+            )}
             {error && (
               <div className="text-sm text-red-500">
                 {error}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { NextAuthOptions } from "next-auth"
 import CredentialsProvider from "next-auth/providers/credentials"
 import { compare } from "bcrypt"
+import speakeasy from "speakeasy"
 import { prisma } from '@/lib/prisma'
 
 // Hapus instansiasi PrismaClient langsung; gunakan singleton prisma
@@ -11,7 +12,8 @@ export const authOptions: NextAuthOptions = {
       name: "Credentials",
       credentials: {
         email: { label: "Email", type: "email" },
-        password: { label: "Password", type: "password" }
+        password: { label: "Password", type: "password" },
+        otp: { label: "One-Time Password", type: "text" }
       },
       async authorize(credentials) {
         try {
@@ -36,8 +38,22 @@ export const authOptions: NextAuthOptions = {
             console.warn('[AUTH] Invalid password for', email)
             return null
           }
+
+          if (user.twoFactorEnabled) {
+            if (!credentials.otp) {
+              throw new Error('OTP_REQUIRED')
+            }
+            const verified = speakeasy.totp.verify({
+              secret: user.twoFactorSecret!,
+              encoding: 'base32',
+              token: credentials.otp
+            })
+            if (!verified) {
+              throw new Error('INVALID_OTP')
+            }
+          }
           console.log('[AUTH] Login success', email, 'role=', user.role)
-          return { id: user.id, email: user.email, name: user.name, role: user.role }
+          return { id: user.id, email: user.email, name: user.name, role: user.role, twoFactorEnabled: user.twoFactorEnabled, twoFactorVerified: true }
         } catch (e) {
           console.error('[AUTH] Authorize error', e)
           return null
@@ -48,7 +64,7 @@ export const authOptions: NextAuthOptions = {
   callbacks: {
     async jwt({ token, user, trigger, session }) {
       if (user) {
-        return { ...token, id: user.id, role: (user as any).role }
+        return { ...token, id: user.id, role: (user as any).role, twoFactorEnabled: (user as any).twoFactorEnabled, twoFactorVerified: (user as any).twoFactorVerified }
       }
       if (trigger === "update" && session) {
         return { ...token, ...session }
@@ -57,13 +73,13 @@ export const authOptions: NextAuthOptions = {
         if (token.email) {
           const latestUser = await prisma.user.findUnique({
             where: { email: token.email as string },
-            select: { id: true, role: true }
+            select: { id: true, role: true, twoFactorEnabled: true }
           })
-          if (latestUser && latestUser.role !== token.role) {
-            return { ...token, role: latestUser.role }
+          if (latestUser && (latestUser.role !== token.role || latestUser.twoFactorEnabled !== token.twoFactorEnabled)) {
+            return { ...token, role: latestUser.role, twoFactorEnabled: latestUser.twoFactorEnabled }
           }
         }
-      } catch (e) {
+      } catch {
         // swallow
       }
       return token
@@ -74,7 +90,9 @@ export const authOptions: NextAuthOptions = {
         user: {
           ...session.user,
           id: token.id,
-          role: token.role
+          role: token.role,
+          twoFactorEnabled: token.twoFactorEnabled,
+          twoFactorVerified: token.twoFactorVerified
         }
       }
     }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -23,7 +23,13 @@ export async function middleware(request: NextRequest) {
         console.log("No token found, redirecting to signin");
         return NextResponse.redirect(new URL("/auth/signin", request.url));
       }
-      
+
+      // Require OTP verification if enabled
+      if (token.twoFactorEnabled && !token.twoFactorVerified) {
+        console.log("2FA not verified, redirecting to signin");
+        return NextResponse.redirect(new URL("/auth/signin", request.url));
+      }
+
       // Check if user has SELLER role
       if (token.role !== "SELLER") {
         console.log("User is not a seller, redirecting to dashboard");

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,4 +1,4 @@
-import { User, UserRole } from "@prisma/client"
+import { UserRole } from "@prisma/client"
 import { DefaultSession } from "next-auth"
 
 declare module "next-auth" {
@@ -6,11 +6,24 @@ declare module "next-auth" {
     user: {
       id: string
       role: UserRole
+      twoFactorEnabled?: boolean
+      twoFactorVerified?: boolean
     } & DefaultSession["user"]
   }
 
   interface User {
     id: string
     role: UserRole
+    twoFactorEnabled?: boolean
+    twoFactorVerified?: boolean
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    id?: string
+    role?: UserRole
+    twoFactorEnabled?: boolean
+    twoFactorVerified?: boolean
   }
 }


### PR DESCRIPTION
## Summary
- add two-factor fields to User schema
- support TOTP in NextAuth and login UI
- expose APIs to enable, verify, and disable 2FA

## Testing
- `npx prisma generate`
- `npx prisma validate` *(fails: Environment variable not found: DATABASE_URL)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a82ee3b4b88332a309c766007d4826